### PR TITLE
Replace Informal Fork for CometBFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo will later also be imported from the github.com/decentralists/DAO.
 
 * [tendermintcore](https://github.com/tendermint/tendermint) - The latest safe version used for cosmoshub-4.
 * [tendermint2](https://github.com/tendermint/tendermint2) - The "purists" minimal Tendermint fork. Version 2. 
-* [informalsystems](https://github.com/informalsystems/tendermint) - Informal Systems fork of tendermint.
+* [CometBFT](https://github.com/cometbft/cometbft) - Tendermint Fork & beyond maintained by Informal Systems 
 * [TODO](github.com) - Add your fork here.
 
 Besides making a PR here, there is a related survey form.


### PR DESCRIPTION
With the announcement of CometBFT, Informal is no longer pushing their fork of tendermint but rather focusing on CometBFT, a forked tendermint.